### PR TITLE
chore: agregar clase NotaPrueba para práctica de merge

### DIFF
--- a/src/main/java/com/biblio/virtual/NotaPrueba.java
+++ b/src/main/java/com/biblio/virtual/NotaPrueba.java
@@ -1,0 +1,11 @@
+package com.biblio.virtual;
+
+
+ /* Clase de prueba para demostrar la creación de ramas y fusión (merge).
+  No afecta la lógica del sistema. */
+ 
+public class NotaPrueba {
+    public static void mostrarMensaje() {
+        System.out.println("Este es un archivo de prueba para practicar Git merge.");
+    }
+}


### PR DESCRIPTION
Se creó la clase NotaPrueba.java dentro de com.biblio.virtual
Este cambio es solo de prueba para practicar la fusión de ramas.
